### PR TITLE
Add staging workflow and fix flaky City Council test

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,87 @@
+name: Staging
+
+on:
+  schedule:
+    - cron: "0 5 * * *"
+  push:
+    branches:
+      - staging
+  workflow_dispatch:
+
+env:
+  CI: true
+  PYTHON_VERSION: 3.11
+  PIPENV_VENV_IN_PROJECT: true
+  CITY_SCRAPERS_ENV: staging
+  SCRAPY_SETTINGS_MODULE: city_scrapers.settings.staging
+  AUTOTHROTTLE_MAX_DELAY: 30.0
+  AUTOTHROTTLE_START_DELAY: 1.5
+  AUTOTHROTTLE_TARGET_CONCURRENCY: 3.0
+  AZURE_ACCOUNT_KEY: ${{ secrets.AZURE_ACCOUNT_KEY }}
+  AZURE_ACCOUNT_NAME: ${{ secrets.AZURE_ACCOUNT_NAME }}
+  AZURE_STAGING_CONTAINER: ${{ secrets.AZURE_STAGING_CONTAINER }}
+  SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+jobs:
+  crawl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: staging
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Pipenv
+        run: |
+          python -m pip install --upgrade pip
+          pip install pipenv
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: ${{ env.PYTHON_VERSION }}-${{ hashFiles('**/Pipfile.lock') }}
+          restore-keys: |
+            ${{ env.PYTHON_VERSION }}-
+            pip-
+
+      - name: Check and conditionally remove invalid virtual environment
+        run: |
+          if [ -d ".venv" ] && [ ! -f ".venv/bin/python" ]; then
+            echo "Virtual environment exists but Python executable is missing. Rebuilding."
+            rm -rf .venv
+          elif ! .venv/bin/python --version 2>&1 | grep -q "Python ${{ env.PYTHON_VERSION }}"; then
+            echo "Virtual environment Python version mismatch. Rebuilding."
+            rm -rf .venv
+          elif [ ! -d ".venv" ]; then
+            echo "No virtual environment found. Will build new one."
+          else
+            echo "Virtual environment appears valid. Reusing."
+          fi
+
+      - name: Install dependencies
+        run: pipenv sync
+        env:
+          PIPENV_DEFAULT_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
+
+      - name: Run scrapers
+        run: |
+          export PYTHONPATH=$(pwd):$PYTHONPATH
+          ./.deploy.sh
+
+      - name: Combine output feeds
+        run: |
+          export PYTHONPATH=$(pwd):$PYTHONPATH
+          pipenv run scrapy combinefeeds -s LOG_ENABLED=False
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1

--- a/city_scrapers/settings/staging.py
+++ b/city_scrapers/settings/staging.py
@@ -1,0 +1,43 @@
+import os
+
+from .base import *  # noqa
+
+USER_AGENT = "City Scrapers [staging mode]. Learn more and say hello at https://citybureau.org/city-scrapers"  # noqa
+
+# Configure item pipelines
+ITEM_PIPELINES = {
+    "city_scrapers_core.pipelines.AzureDiffPipeline": 200,
+    "city_scrapers_core.pipelines.MeetingPipeline": 300,
+    "city_scrapers_core.pipelines.OpenCivicDataPipeline": 400,
+}
+
+SENTRY_DSN = os.getenv("SENTRY_DSN")
+
+EXTENSIONS = {
+    "scrapy_sentry_errors.extensions.Errors": 10,
+    "scrapy.extensions.closespider.CloseSpider": None,
+}
+
+FEED_EXPORTERS = {
+    "json": "scrapy.exporters.JsonItemExporter",
+    "jsonlines": "scrapy.exporters.JsonLinesItemExporter",
+}
+
+FEED_FORMAT = "jsonlines"
+
+FEED_STORAGES = {
+    "azure": "city_scrapers_core.extensions.AzureBlobFeedStorage",
+}
+
+AZURE_ACCOUNT_NAME = os.getenv("AZURE_ACCOUNT_NAME")
+AZURE_ACCOUNT_KEY = os.getenv("AZURE_ACCOUNT_KEY")
+AZURE_CONTAINER = os.getenv("AZURE_STAGING_CONTAINER")
+
+FEED_URI = (
+    "azure://{account_name}:{account_key}@{container}"
+    "/%(year)s/%(month)s/%(day)s/%(hour_min)s/%(name)s.json"
+).format(
+    account_name=AZURE_ACCOUNT_NAME,
+    account_key=AZURE_ACCOUNT_KEY,
+    container=AZURE_CONTAINER,
+)

--- a/tests/files/fortx_Fort_Worth_City_Council_detail_page.html
+++ b/tests/files/fortx_Fort_Worth_City_Council_detail_page.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+<div class="side-box consultation-snapshot">
+  <div class="side-box-title">Agenda</div>
+  <div class="side-box-section body-content">
+    <a href="/files/assets/public/v/2/city-secretary/documents/calendar/2024-agendas/city-council/executive-session/01-09-24-executive-session.pdf">01-09-24-executive-session.pdf</a>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/test_fortx_Fort_Worth_City_Council.py
+++ b/tests/test_fortx_Fort_Worth_City_Council.py
@@ -46,7 +46,10 @@ mock_response.text = detail_page_html
 
 parsed_items = []
 
-with patch("city_scrapers.spiders.fortx_Fort_Worth_City_Council.requests.get", return_value=mock_response):  # noqa
+with patch(
+    "city_scrapers.spiders.fortx_Fort_Worth_City_Council.requests.get",
+    return_value=mock_response,
+):  # noqa
     for req in spider.parse(meetings_items):
         if isinstance(req, scrapy.Request):
             meeting_detail_item = spider.parse_meeting(

--- a/tests/test_fortx_Fort_Worth_City_Council.py
+++ b/tests/test_fortx_Fort_Worth_City_Council.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from os.path import dirname, join
+from unittest.mock import MagicMock, patch
 
 import pytest
 import scrapy
@@ -29,19 +30,29 @@ meetings_detail = file_response(
     ),
 )
 
+detail_page_path = join(
+    dirname(__file__), "files", "fortx_Fort_Worth_City_Council_detail_page.html"
+)
+with open(detail_page_path) as f:
+    detail_page_html = f.read()
+
 spider = FortxFortWorthCityCouncilSpider()
 
 freezer = freeze_time("2024-12-19")
 freezer.start()
 
+mock_response = MagicMock()
+mock_response.text = detail_page_html
+
 parsed_items = []
 
-for req in spider.parse(meetings_items):
-    if isinstance(req, scrapy.Request):
-        meeting_detail_item = spider.parse_meeting(
-            meetings_detail, req.cb_kwargs["item"]
-        )
-        parsed_items.extend(meeting_detail_item)
+with patch("city_scrapers.spiders.fortx_Fort_Worth_City_Council.requests.get", return_value=mock_response):  # noqa
+    for req in spider.parse(meetings_items):
+        if isinstance(req, scrapy.Request):
+            meeting_detail_item = spider.parse_meeting(
+                meetings_detail, req.cb_kwargs["item"]
+            )
+            parsed_items.extend(meeting_detail_item)
 
 freezer.stop()
 
@@ -107,7 +118,7 @@ def test_source():
 def test_links():
     assert parsed_items[0]["links"] == [
         {
-            "href": "https://www.fortworthtexas.gov//files/assets/public/v/2/city-secretary/documents/calendar/2024-agendas/city-council/executive-session/11-05-2024-executive-session.pdf",  # noqa
+            "href": "https://www.fortworthtexas.gov//files/assets/public/v/2/city-secretary/documents/calendar/2024-agendas/city-council/executive-session/01-09-24-executive-session.pdf",  # noqa
             "title": "Agenda",
         }
     ]


### PR DESCRIPTION
## Summary
- Add staging workflow (`staging.yml`) and staging settings (`staging.py`) for staging environment
- Fix flaky `test_links` in City Council test by mocking the live `requests.get` call with an HTML fixture

## Test plan
- [ ] Verify CI passes (lint + tests)
- [ ] Confirm `AZURE_STAGING_CONTAINER` secret is set in repo settings
- [ ] Create `staging` branch to trigger the workflow