### PR TITLE
Update city-scrapers-core to v0.10.2

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -232,7 +232,7 @@
             ],
             "git": "https://github.com/City-Bureau/city-scrapers-core.git",
             "markers": "python_version >= '3.6' and python_version < '4.0'",
-            "ref": "44ed57f1f4833f7c35276fff4bc5187e191da496"
+            "ref": "78ccb55766bc445eb2c685bd40a769ce673cb2ee"
         },
         "colorama": {
             "hashes": [


### PR DESCRIPTION
Update Pipfile.lock to pick up latest city-scrapers-core (v0.10.2) which marks status badge as failing when zero items scraped.