### PR TITLE
Enable crawl logging in deploy script

### DIFF
--- a/.deploy.sh
+++ b/.deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-pipenv run scrapy list | xargs -I {} pipenv run scrapy crawl {} -s LOG_ENABLED=False &
+pipenv run scrapy list | xargs -I {} pipenv run scrapy crawl {} -s LOG_ENABLED=True &
 
 # Output to the screen every 9 minutes to prevent a travis timeout
 # https://stackoverflow.com/a/40800348


### PR DESCRIPTION
## Summary
- Set `LOG_ENABLED=True` in `.deploy.sh` to match other repos (kancit, lascruc)
- Allows visibility into spider output during staging crawls

## Test plan
- [ ] Verify next staging refresh shows crawl logs in Actions output