### PR TITLE
fix: scope meeting deletion to scraped meetings only

### DIFF
--- a/.github/workflows/refresh-staging.yml
+++ b/.github/workflows/refresh-staging.yml
@@ -253,10 +253,10 @@ jobs:
 
           slug = '${{ secrets.PROGRAM_SLUG }}'
           program_meetings = Meeting.objects.filter(programs__slug=slug)
-          without_assignments = program_meetings.filter(assignments__isnull=True).distinct()
+          without_assignments = program_meetings.scraped().filter(assignments__isnull=True).distinct()
           count = without_assignments.count()
           without_assignments.delete()
-          print(f'Deleted {count} meetings without assignments')
+          print(f'Deleted {count} scraped meetings without assignments')
           PYEOF
 
       - name: Queue data import


### PR DESCRIPTION
## Summary
- Use `.scraped()` queryset filter in refresh-staging workflow to only delete scraped meetings without assignments
- Prevents accidental deletion of manually created meetings

## Test plan
- [ ] Verify workflow runs successfully with `workflow_dispatch`