### PR TITLE
Add python-dateutil to [packages] so prod cron can load spiders

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ city-scrapers-core = {ref = "main", git = "https://github.com/City-Bureau/city-s
 scrapy-wayback-middleware = "*"
 colorama = "*"
 tzdata = "*"
+python-dateutil = "*"
 
 [dev-packages]
 freezegun = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -657,6 +657,15 @@
             "markers": "python_version >= '3.8'",
             "version": "==26.0.0"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.9.0.post0"
+        },
         "pytz": {
             "hashes": [
                 "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1",


### PR DESCRIPTION
## Summary

Adds `python-dateutil = \"*\"` to `[packages]` in `Pipfile` and the corresponding entry in the `default` section of `Pipfile.lock`.

## Why

7 spiders import \`from dateutil.parser import parse\`:
- \`fortx_Castleberry_ISD\`
- \`fortx_Fort_Worth_City_Council\`
- \`fortx_Fort_Worth_Isd\`
- \`fortx_Fort_Worth_Isd_Coc\`
- \`fortx_Fort_Worth_Isd_Meetings\`
- \`fortx_Fort_Worth_Public_Meetings\`
- \`fortx_Tarrant_County_Commissioners_Court\`

But \`python-dateutil\` only existed in the **develop** section of \`Pipfile.lock\` (pulled in transitively by \`freezegun\`). The cron workflow runs \`pipenv sync\` (without \`--dev\`), so dateutil wasn't installed in prod. Today's cron run on \`main\` failed at scrapy startup with:

\`\`\`
ModuleNotFoundError: No module named 'dateutil'
  File \".../city_scrapers/spiders/fortx_Castleberry_ISD.py\", line 8, in <module>
    from dateutil.parser import parse
\`\`\`

Scrapy loads every spider at module-import time when starting any command, so a single missing dep blocks the entire cron run (scrape + combinefeeds).

Failed run: https://github.com/City-Bureau/city-scrapers-fortx/actions/workflows/cron.yml

## Why is this only surfacing now?

The cron has been failing earlier (at the combinefeeds step) for unrelated reasons; today's manual cron trigger after recent merges got past those earlier failures and revealed this dateutil import error. All 5 other city-scrapers repos already have \`python-dateutil\` in their \`[packages]\`.

## Changes

- **Pipfile**: +1 line (\`python-dateutil = \"*\"\`)
- **Pipfile.lock**: +9 lines (move/copy the existing dateutil entry from \`develop\` into \`default\`, alphabetically between \`pyopenssl\` and \`pytz\`)

The new entry uses the same version (\`==2.9.0.post0\`) and hashes that were already pinned in the develop section, so no other dependency versions change.

## Test plan

- [x] \`pipenv sync\` succeeds (no hash mismatch)
- [x] \`pipenv run python -c 'from dateutil.parser import parse'\` succeeds
- [x] \`pipenv run scrapy list\` lists all 9 spiders without import errors
- [x] \`isort\` / \`black\` / \`flake8\` clean
- [x] \`pytest\` 533/533 pass
- [ ] After merge, re-trigger \`cron.yml\` on \`main\`; combinefeeds step succeeds