### PR TITLE
Add 'six' to Pipfile.lock default section (dateutil transitive dep)

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -916,6 +916,14 @@
             "markers": "python_version >= '3.9'",
             "version": "==82.0.1"
         },
+        "six": {
+            "hashes": [
+                "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+                "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.17.0"
+        },
         "tldextract": {
             "hashes": [
                 "sha256:b3d2b70a1594a0ecfa6967d57251527d58e00bb5a91a74387baa0d87a0678609",


### PR DESCRIPTION
## Summary

After PR #44 added \`python-dateutil\` to \`[packages]\`, the next cron run on \`main\` got further but then failed at:

\`\`\`
ModuleNotFoundError: No module named 'six'
  File '.../dateutil/parser/_parser.py', line 42, in <module>
      import six
\`\`\`

\`six\` is a runtime transitive dep of \`python-dateutil\` 2.9.x. It was already pinned in the **develop** section of \`Pipfile.lock\` (pulled in by some test-only dep), but not in **default**. Cron runs \`pipenv sync\` without \`--dev\`, so \`six\` wasn't installed in prod.

## Changes

- **Pipfile**: unchanged (six is transitive, not a top-level dep)
- **Pipfile.lock**: +8 lines — copies the existing \`six\` entry (version \`==1.17.0\`, same hashes) from the develop section into the default section, alphabetically between \`setuptools\` and \`tldextract\`

## Test plan

- [x] \`pipenv sync\` succeeds, no hash mismatch
- [x] \`pipenv run python -c 'from dateutil.parser import parse; import six'\` works
- [x] \`pipenv run scrapy list\` lists all 9 spiders
- [x] \`isort\` / \`black\` / \`flake8\` clean
- [x] \`pytest\` 533/533 pass
- [ ] After merge, re-trigger \`cron.yml\` on main; combinefeeds step succeeds

Pairs with #44.